### PR TITLE
Context refresh metrics are tagged with the context that succeeded/errored

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN poetry install --no-root
 
 ADD ./src ./src
 RUN poetry install
-RUN poetry install -E ujson -E orjson -E caching -E httptools
+RUN poetry install -E ujson -E orjson -E caching -E httptools -E statsd
 # ==== Add tests
 COPY test ./test
 COPY pytest.ini ./pytest.ini
@@ -49,7 +49,7 @@ FROM dev as production
 ADD ./src ./src
 # Have to include test configs unfortunately
 COPY test ./test
-RUN poetry install --only main -E orjson -E caching -E httptools
+RUN poetry install --only main -E orjson -E caching -E httptools -E statsd
 
 EXPOSE 8080
 CMD sovereign

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - 80
     links:
       - redis
+      - statsd
 
 
   redis:
@@ -94,3 +95,8 @@ services:
     links:
       - envoy-control-plane
       - envoy
+
+  statsd:
+    image: jancajthaml/datadog_mock
+    expose:
+      - 8125

--- a/src/sovereign/context.py
+++ b/src/sovereign/context.py
@@ -50,10 +50,16 @@ class TemplateContext:
                     ret[k] = v.load()
                 elif isinstance(v, str):
                     ret[k] = Loadable.from_legacy_fmt(v).load()
-                self.stats.increment("context.refresh.success")
+                self.stats.increment(
+                    "context.refresh.success",
+                    tags=[f"context:{k}"],
+                )
             except Exception as e:
                 self.logger(event=e)
-                self.stats.increment("context.refresh.error")
+                self.stats.increment(
+                    "context.refresh.error",
+                    tags=[f"context:{k}"],
+                )
         if "crypto" not in ret:
             ret["crypto"] = self.crypto
         return ret

--- a/src/sovereign/context.py
+++ b/src/sovereign/context.py
@@ -26,10 +26,10 @@ class TemplateContext:
         self.configured_context = configured_context
         self.crypto = encryption_suite
         self.disabled_suite = disabled_suite
-        # initial load
-        self.context = self.load_context_variables()
         self.logger = logger
         self.stats = stats
+        # initial load
+        self.context = self.load_context_variables()
 
     async def start_refresh_context(self) -> NoReturn:
         if self.refresh_cron is not None:

--- a/test/config/config.yaml
+++ b/test/config/config.yaml
@@ -143,3 +143,11 @@ eds_priority_matrix:
     eu-central-1:   6
     ap-southeast-2: 7
     ap-southeast-1: 8
+
+statsd:
+  host: statsd
+  port: 8125
+  tags: {}
+  namespace: sovereign
+  enabled: true
+  use_ms: true

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -1,0 +1,27 @@
+from sovereign.context import TemplateContext
+from unittest.mock import Mock
+from sovereign.config_loader import Loadable, Serialization, Protocol
+
+def test_initialises_context() -> None:
+    mock_stats = Mock()
+    mock_stats.increment = Mock()
+    configured_context = {
+        "foo": Loadable(
+            protocol=Protocol.inline,
+            serialization=Serialization.raw,
+            path="bar",
+        ),
+    }
+
+    context = TemplateContext(
+        refresh_rate=None,
+        refresh_cron=None,
+        configured_context=configured_context,
+        poller=None,
+        encryption_suite=None,
+        disabled_suite=None,
+        logger=None,
+        stats=mock_stats,
+    )
+    
+    assert context.context["foo"] == "bar"

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock
 from sovereign.config_loader import Loadable, Serialization, Protocol
 
 def test_init_context() -> None:
-    mock_stats = Mock()
     configured_context = {
         "foo": Loadable(
             protocol=Protocol.inline,
@@ -20,7 +19,7 @@ def test_init_context() -> None:
         encryption_suite=None,
         disabled_suite=None,
         logger=None,
-        stats=mock_stats,
+        stats=Mock(),
     )
     
     assert context.context["foo"] == "bar"
@@ -49,4 +48,29 @@ def test_emit_metric_when_successfully_init_context() -> None:
 
     assert mock_stats.increment.call_count == 1
     mock_stats.increment.assert_called_with("context.refresh.success", tags=["context:foo"])
+    
+def test_emit_metric_when_failed_to_init_context() -> None:
+    mock_stats = Mock()
+    mock_stats.increment = Mock()
+    configured_context = {
+        "foo": Loadable(
+            protocol=Protocol.file,
+            serialization=Serialization.json,
+            path="bad_path",
+        ),
+    }
+
+    TemplateContext(
+        refresh_rate=None,
+        refresh_cron=None,
+        configured_context=configured_context,
+        poller=None,
+        encryption_suite=None,
+        disabled_suite=None,
+        logger=Mock(),
+        stats=mock_stats,
+    )
+
+    assert mock_stats.increment.call_count == 1
+    mock_stats.increment.assert_called_with("context.refresh.error", tags=["context:foo"])
     

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -2,6 +2,7 @@ from sovereign.context import TemplateContext
 from unittest.mock import Mock
 from sovereign.config_loader import Loadable, Serialization, Protocol
 
+
 def test_init_context() -> None:
     configured_context = {
         "foo": Loadable(
@@ -21,8 +22,9 @@ def test_init_context() -> None:
         logger=None,
         stats=Mock(),
     )
-    
+
     assert context.context["foo"] == "bar"
+
 
 def test_emit_metric_when_successfully_init_context() -> None:
     mock_stats = Mock()
@@ -47,8 +49,11 @@ def test_emit_metric_when_successfully_init_context() -> None:
     )
 
     assert mock_stats.increment.call_count == 1
-    mock_stats.increment.assert_called_with("context.refresh.success", tags=["context:foo"])
-    
+    mock_stats.increment.assert_called_with(
+        "context.refresh.success", tags=["context:foo"]
+    )
+
+
 def test_emit_metric_when_failed_to_init_context() -> None:
     mock_stats = Mock()
     mock_stats.increment = Mock()
@@ -72,5 +77,6 @@ def test_emit_metric_when_failed_to_init_context() -> None:
     )
 
     assert mock_stats.increment.call_count == 1
-    mock_stats.increment.assert_called_with("context.refresh.error", tags=["context:foo"])
-    
+    mock_stats.increment.assert_called_with(
+        "context.refresh.error", tags=["context:foo"]
+    )

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -2,9 +2,8 @@ from sovereign.context import TemplateContext
 from unittest.mock import Mock
 from sovereign.config_loader import Loadable, Serialization, Protocol
 
-def test_initialises_context() -> None:
+def test_init_context() -> None:
     mock_stats = Mock()
-    mock_stats.increment = Mock()
     configured_context = {
         "foo": Loadable(
             protocol=Protocol.inline,
@@ -25,3 +24,29 @@ def test_initialises_context() -> None:
     )
     
     assert context.context["foo"] == "bar"
+
+def test_emit_metric_when_successfully_init_context() -> None:
+    mock_stats = Mock()
+    mock_stats.increment = Mock()
+    configured_context = {
+        "foo": Loadable(
+            protocol=Protocol.inline,
+            serialization=Serialization.raw,
+            path="bar",
+        ),
+    }
+
+    TemplateContext(
+        refresh_rate=None,
+        refresh_cron=None,
+        configured_context=configured_context,
+        poller=None,
+        encryption_suite=None,
+        disabled_suite=None,
+        logger=None,
+        stats=mock_stats,
+    )
+
+    assert mock_stats.increment.call_count == 1
+    mock_stats.increment.assert_called_with("context.refresh.success", tags=["context:foo"])
+    


### PR DESCRIPTION
We are looking to take advantage of template context data that is loaded from S3. In the event we misconfigure S3 or if it goes down 💀 , we would like to be notified.

This change updates the existing `context.refresh.success` and `context.refresh.error` metrics to be tagged with the relevant context being refreshed.

![Screen Shot 2023-04-21 at 9 51 03 am](https://user-images.githubusercontent.com/13991375/233510922-b096b47c-30a0-4df1-b0aa-5b1cfb6a361d.png)

Additional changes:
* Support statsd in the local dev environment `make run-daemon`, so we can inspect the metrics