### PR TITLE
Switch to supervisor-managed uvicorn

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1895,6 +1895,27 @@ starlite = ["starlite (>=1.48)"]
 tornado = ["tornado (>=6)"]
 
 [[package]]
+name = "setuptools"
+version = "80.9.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"},
+    {file = "setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.8.0) ; sys_platform != \"cygwin\""]
+core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
+type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1983,6 +2004,24 @@ dev = ["structlog[tests,typing]"]
 docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "sphinxext-opengraph", "twisted"]
 tests = ["freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=0.17)", "simplejson"]
 typing = ["mypy (>=1.4)", "rich", "twisted"]
+
+[[package]]
+name = "supervisor"
+version = "4.2.5"
+description = "A system for controlling process state under UNIX"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "supervisor-4.2.5-py2.py3-none-any.whl", hash = "sha256:2ecaede32fc25af814696374b79e42644ecaba5c09494c51016ffda9602d0f08"},
+    {file = "supervisor-4.2.5.tar.gz", hash = "sha256:34761bae1a23c58192281a5115fb07fbf22c9b0133c08166beffc70fed3ebc12"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[package.extras]
+testing = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "tavern"
@@ -2324,4 +2363,4 @@ ujson = ["ujson"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "1bac01f47effabfc6fc6e62ff8b809fa4620faf5a7415273f69e439b84ddb7c1"
+content-hash = "76364e8252e6cf5f9edbf973d287234af65a759904b40e5ed142666b5a8a3ba4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ cachetools = "^5.3.2"
 pydantic = "^2.7.2"
 pydantic-settings = "<2.6.0"
 starlette-context = "^0.3.6"
+supervisor = "^4.2.5"
 
 [tool.poetry.extras]
 sentry = ["sentry-sdk"]

--- a/src/sovereign/server.py
+++ b/src/sovereign/server.py
@@ -1,50 +1,54 @@
-import gunicorn.app.base
-from fastapi import FastAPI
-from typing import Optional, Dict, Any, Callable
+from __future__ import annotations
+
+import sys
+import tempfile
+from textwrap import dedent
+
+import uvicorn
+from supervisor import supervisord
+
 from sovereign import asgi_config
 from sovereign.app import app
-from sovereign.utils.entry_point_loader import EntryPointLoader
 
 
-class StandaloneApplication(gunicorn.app.base.BaseApplication):  # type: ignore
-    _HOOKS = ["pre_fork", "post_fork"]
+def uvicorn_entrypoint() -> None:
+    """Run a single uvicorn instance using FD 0 for the socket."""
+    uvicorn.run(
+        app,
+        fd=0,
+        log_level=asgi_config.log_level,
+        access_log=False,
+    )
 
-    def __init__(
-        self, application: FastAPI, options: Optional[Dict[str, Any]] = None
-    ) -> None:
-        self.loader = EntryPointLoader(*self._HOOKS)
-        self.options = options or {}
-        self.application = application
-        super().__init__()
 
-    def load_config(self) -> None:
-        for key, value in self.options.items():
-            self.cfg.set(key.lower(), value)
+def make_supervisor_conf() -> str:
+    command = f"{sys.executable} -m sovereign.server uvicorn"
+    return dedent(
+        f"""
+        [supervisord]
+        nodaemon=true
 
-        for hook in self._HOOKS:
-            self._install_hooks(hook)
-
-    def _install_hooks(self, name: str) -> None:
-        hooks: list[Callable[[Any, Any], None]] = [
-            ep.load() for ep in self.loader.groups[name]
-        ]
-
-        def master_hook(server: Any, worker: Any) -> None:
-            for hook in hooks:
-                hook(server, worker)
-
-        self.cfg.set(name, master_hook)
-
-    def load(self) -> FastAPI:
-        return self.application
+        [fcgi-program:uvicorn]
+        socket=tcp://{asgi_config.host}:{asgi_config.port}
+        command={command}
+        numprocs={asgi_config.workers}
+        process_name=uvicorn-%(process_num)d
+        stdout_logfile=/dev/stdout
+        stdout_logfile_maxbytes=0
+        """
+    )
 
 
 def main() -> None:
-    asgi = StandaloneApplication(
-        application=app, options=asgi_config.as_gunicorn_conf()
-    )
-    asgi.run()
+    conf = make_supervisor_conf()
+    with tempfile.NamedTemporaryFile("w", delete=False) as f:
+        f.write(conf)
+        path = f.name
+    supervisord.main(["-c", path])
 
 
 if __name__ == "__main__":
-    main()
+    if len(sys.argv) > 1 and sys.argv[1] == "uvicorn":
+        uvicorn_entrypoint()
+    else:
+        main()


### PR DESCRIPTION
## Summary
- replace gunicorn setup with supervisor that spawns uvicorn processes
- provide a function for the workers to run uvicorn
- add supervisor as a dependency

## Testing
- `poetry run ruff check src/sovereign`
- `poetry run ruff format --check src/sovereign`
- `poetry run mypy src/sovereign`
- `poetry run pytest -q` *(fails: Exception: self.protocol='http', self.path='http://mock:8000/data', self.serialization='json', original_error=HTTPError('403 Client Error: Forbidden for url: http://mock:8000/data'))*

------
https://chatgpt.com/codex/tasks/task_e_68458b61ae4483299c64178cf4d28fe2